### PR TITLE
FIX: center align column layout of default marker to remove incorrect…

### DIFF
--- a/lib/src/location_marker.dart
+++ b/lib/src/location_marker.dart
@@ -19,6 +19,7 @@ class LocationMarker extends StatelessWidget {
     final double diameter = ld != null && ld.highAccurency() ? 22.0 : 80.0;
     return Container(
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Stack(
             alignment: AlignmentDirectional.center,


### PR DESCRIPTION
… offset.

Without MainAxisAlignment.center alignment, this widget will align to top of enclosing Marker widget, resulting in false map position.