### PR TITLE
flutter_map Version 0.12.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/Xennis/flutter_map_location
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_compass: ^0.5.1
-  flutter_map: ^0.11.0
+  flutter_map: ^0.12.0
   latlong: ^0.6.1
   location: ^3.2.4
 


### PR DESCRIPTION
Updated Dependencies:
- flutter sdk to 2.0.0
- flutter_map to 0.12.0

since flutter_map depends on Flutter 2 now, the sdk version had to be updated