### PR TITLE
Moved archived latlong to latlong2

### DIFF
--- a/lib/src/location_layer.dart
+++ b/lib/src/location_layer.dart
@@ -5,15 +5,15 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_compass/flutter_compass.dart';
 import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_location/src/types.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:location/location.dart';
-import 'package:latlong/latlong.dart';
 
 import 'location_marker.dart';
 import 'location_options.dart';
 
 LocationMarkerBuilder _defaultMarkerBuilder =
     (BuildContext context, LatLngData ld, ValueNotifier<double> heading) {
-  final double diameter = ld != null && ld.highAccurency() ? 60.0 : 120.0;
+  final double diameter = ld != null && ld.highAccuracy() ? 60.0 : 120.0;
   return Marker(
     point: ld.location,
     builder: (_) => LocationMarker(ld: ld, heading: heading),

--- a/lib/src/location_marker.dart
+++ b/lib/src/location_marker.dart
@@ -16,7 +16,7 @@ class LocationMarker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double diameter = ld != null && ld.highAccurency() ? 22.0 : 80.0;
+    final double diameter = ld != null && ld.highAccuracy() ? 22.0 : 80.0;
     return Container(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -31,7 +31,7 @@ class LocationMarker extends StatelessWidget {
                       return Container();
                     }
                     // Only display heading for an accurate location.
-                    if (ld == null || !ld.highAccurency()) {
+                    if (ld == null || !ld.highAccuracy()) {
                       return Container();
                     }
                     return Transform.rotate(

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,4 +1,4 @@
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 
 class LatLngData {
   const LatLngData(this.location, this.accuracy);
@@ -8,7 +8,7 @@ class LatLngData {
   /// Estimated horizontal accuracy, radial, in meters.
   final double accuracy;
 
-  bool highAccurency() {
+  bool highAccuracy() {
     return !(accuracy == null || accuracy <= 0.0 || accuracy > 30.0);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_compass: ^0.6.0
   flutter_map: ^0.12.0
-  latlong: ^0.6.1
+  latlong2: ^0.8.0
   location: ^4.1.1
 
 dev_dependencies:


### PR DESCRIPTION
The `flutter_map` package recently moved its coordinate implementation from `latlong` to `latlong2` as `latlong` was marked as discontinued by its maintainers. I did this change for this package too.

Please note that the changes won't work up to now as the updated `flutter_map` is not published yet. To test this change, please override `flutter_map` to be imported from upstream master.

I already implemented this change even though the upstream is not published yet as I would like to avoid a transition time in which this package won't be usable.