### PR TITLE
Added option not to ask for location permission at the beginning

### DIFF
--- a/lib/src/location_layer.dart
+++ b/lib/src/location_layer.dart
@@ -5,8 +5,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_compass/flutter_compass.dart';
 import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_location/src/types.dart';
-import 'package:location/location.dart';
 import 'package:latlong/latlong.dart';
+import 'package:location/location.dart';
 
 import 'location_marker.dart';
 import 'location_options.dart';
@@ -53,9 +53,11 @@ class _LocationLayerState extends State<LocationLayer>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _location.changeSettings(interval: widget.options.updateIntervalMs);
-    _locationRequested = true;
-    _initOnLocationUpdateSubscription()
-        .then((LocationServiceStatus status) => _serviceStatus.value = status);
+    if (widget.options.initiallyRequest) {
+      _locationRequested = true;
+      _initOnLocationUpdateSubscription().then(
+          (LocationServiceStatus status) => _serviceStatus.value = status);
+    }
     _lastLocation.addListener(() {
       final LatLngData loc = _lastLocation.value;
       widget.options.onLocationUpdate?.call(loc);
@@ -121,7 +123,7 @@ class _LocationLayerState extends State<LocationLayer>
       if (_serviceStatus?.value != LocationServiceStatus.subscribed ||
           _lastLocation?.value == null ||
           !await _location.serviceEnabled()) {
-        _initOnLocationUpdateSubscription().then(
+        _initOnLocationUpdateSubscription(forceRequestLocation: true).then(
             (LocationServiceStatus value) => _serviceStatus.value = value);
         _locationRequested = true;
       } else {
@@ -130,15 +132,19 @@ class _LocationLayerState extends State<LocationLayer>
     });
   }
 
-  Future<LocationServiceStatus> _initOnLocationUpdateSubscription() async {
+  Future<LocationServiceStatus> _initOnLocationUpdateSubscription(
+      {bool forceRequestLocation = false}) async {
     if (!await _location.serviceEnabled()) {
       _lastLocation.value = null;
       return LocationServiceStatus.disabled;
     }
     if (await _location.hasPermission() == PermissionStatus.denied) {
-      if (await _location.requestPermission() != PermissionStatus.granted) {
-        _lastLocation.value = null;
-        return LocationServiceStatus.permissionDenied;
+      if (widget.options.initiallyRequest || forceRequestLocation) {
+        if (await _location.requestPermission() != PermissionStatus.granted) {
+          _lastLocation.value = null;
+          return LocationServiceStatus.permissionDenied;
+        } else
+          return LocationServiceStatus.permissionDenied;
       }
     }
     await _onLocationChangedSub?.cancel();

--- a/lib/src/location_options.dart
+++ b/lib/src/location_options.dart
@@ -24,7 +24,8 @@ class LocationOptions extends LayerOptions {
       this.onLocationRequested,
       @required this.buttonBuilder,
       this.markerBuilder,
-      this.updateIntervalMs = 1000})
+      this.updateIntervalMs = 1000,
+      this.initiallyRequest = false})
       : assert(markers != null, buttonBuilder != null),
         super();
 
@@ -33,5 +34,6 @@ class LocationOptions extends LayerOptions {
   final LocationButtonBuilder buttonBuilder;
   final LocationMarkerBuilder markerBuilder;
   final int updateIntervalMs;
+  final bool initiallyRequest;
   List<Marker> markers;
 }


### PR DESCRIPTION
The `LocationOptions` have been given an option not to ask for the Location permission when the map is initially shown. This is particularly useful in case the own position should only be shown on demand.