### PR TITLE
Migrated underlaying location plugin to geolocator plugin

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -73,7 +73,7 @@ linter:
     - empty_constructor_bodies
     - empty_statements
     # - file_names
-    - flutter_style_todos
+    # - flutter_style_todos
     - hash_and_equals
     - implementation_imports
     # - invariant_booleans # too many false positives

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
   flutter_compass: ^0.6.0
   flutter_map: ^0.12.0
+  geolocator: ^7.0.3
   latlong: ^0.6.1
-  location: ^4.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**Why did we do this?**

I really like the `location` plugin's Dart interface, but unfortunately, the underlying native code is awful; both of style and documentation. For our use case, we decided to get rid of the `location` plugin hence and to move to `geolocator` plugin.

Another advantage is compatibility: the `geolocator` plugin does not rely uniquely on the GMS, but works with `LocationManager` (native AOSP location implementation) too. An HMS (Huawei mobility service) implementation is on its way.

In my opinion, free dependencies as in open source are in the spirit of Open Street Map. This is why I propose to use the provided modifications to migrate to `geolocator`.